### PR TITLE
Adds missing `await` to S3 download example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -163,7 +163,7 @@ Here we pull the object from S3 in chunks and serve it out to a HTTP request via
             await resp.prepare(request)
 
             stream = s3_ob["Body"]
-            while file_data := stream.read(chunk_size):
+            while file_data := await stream.read(chunk_size):
                 await resp.write(file_data)
 
         return resp


### PR DESCRIPTION
This simple PR just add a missing `await` to our examples. Without that `await` for an asyncio read, we end up with:

```
TypeError: a bytes-like object is required, not 'coroutine'
sys:1: RuntimeWarning: coroutine 'StreamingBody.read' was never awaited
```