### PR TITLE
Add jmespath and botocore as explicit dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ classifiers = [
 python = "^3.8"
 aiobotocore = {version = "2.13.1", extras = ["boto3"]}
 aiofiles = {version = ">=23.2.1"}
+botocore = {version = ">=1.12.0"}
 cryptography = {version = ">=2.3.1", optional = true}
 chalice = {version = ">=1.24.0", optional = true}
+jmespath = {version = ">=0.7.1,<2.0.0"}
 
 [tool.poetry.extras]
 s3cse = ["cryptography"]


### PR DESCRIPTION
Over on conda-forge ecosystem, their automatic dependencies checker identified that jmespath and botocore are explicitly imported in the code - see https://github.com/conda-forge/aioboto3-feedstock/pull/9

Here propose to add them as dependencies.

I did a best effort to determine compatible versions with botocore going back >6 years and had the used features and jmespath from boto's pinning.

I am very happy for this to be rejected, as these things can be personal preference and we can just them to conda-forge ecosystem.