### PR TITLE
Convert download_fileobj logline from info to debug.

### DIFF
--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -283,7 +283,7 @@ async def download_fileobj(
         if queue_reader_future:
             await queue_reader_future
 
-        logger.info(f'Downloaded file from {Bucket}/{Key}')
+        logger.debug(f'Downloaded file from {Bucket}/{Key}')
 
     except ClientError as e:
         raise Exception(


### PR DESCRIPTION
For the download_fileobj operation, which has been overridden in inject, a succesful transfer generates a logline that looks something like this:
2024-07-28 15:52:43,308 INFO inject "Downloaded file from xxxxxxx/TYPO3_INSTALLATION/eudsamf.ibog.xxxxxx.xx_1722174744-ZQHDBEGI.db.gz"

Atleast for my project, this logline will mostly cause confusion.
This change converts this to debug, which is consistent with other logging in inject.py.