### PR TITLE
Fix checksums in multipart uploads in `upload_fileobj`

### DIFF
--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -417,7 +417,14 @@ async def upload_fileobj(
                 break
 
             # Success, add the result to the finished_parts, increment the sent_bytes
-            finished_parts.append({'ETag': resp['ETag'], 'PartNumber': part_args['PartNumber']})
+
+            finished_parts_kwargs = {}
+            if 'ChecksumAlgorithm' in kwargs:
+                for key in resp:
+                    if key.startswith('Checksum'):
+                        finished_parts_kwargs[key] = resp[key]
+            finished_parts.append(
+                {'ETag': resp['ETag'], 'PartNumber': part_args['PartNumber'], **finished_parts_kwargs})
             current_bytes = len(part_args['Body'])
             sent_bytes += current_bytes
             uploaded_parts += 1

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import tempfile
 from io import BytesIO
+from unittest.mock import AsyncMock
 
 from botocore.exceptions import ClientError
 from boto3.s3.transfer import S3TransferConfig
@@ -183,6 +184,46 @@ async def test_s3_upload_fileobj_async_multipart(event_loop, s3_client, bucket_n
 
     resp = await s3_client.get_object(Bucket=bucket_name, Key='test_file')
     assert (await resp['Body'].read()) == data
+
+@pytest.mark.parametrize('checksum_algo', ['CRC32', 'SHA1', None])
+@pytest.mark.asyncio
+async def test_s3_upload_fileobj_async_multipart_completes_with_checksum_on_parts(
+    event_loop, s3_client, bucket_name, region, checksum_algo):
+    """This test verifies that when performing a multipart upload with a checksum algorithm:
+    1. Each uploaded part includes the specified checksum type (e.g. CRC32 or SHA1)
+    2. The complete_multipart_upload call receives all part checksums correctly
+    """
+    await s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': region})
+
+    data = b'Hello World\n'
+
+    tmpfile = tempfile.NamedTemporaryFile(delete=False)
+    tmpfile.close()
+    async with aiofiles.open(tmpfile.name, mode='wb') as fpw:
+        await fpw.write(data)
+
+    mock_complete_multipart_upload = AsyncMock()
+    s3_client.complete_multipart_upload = mock_complete_multipart_upload
+    async with aiofiles.open(tmpfile.name, mode='rb') as fpr:
+        config = S3TransferConfig(multipart_threshold=4)
+
+        upload_fileobj_kwargs = {}
+        if checksum_algo:
+            upload_fileobj_kwargs = {'ExtraArgs': {'ChecksumAlgorithm': checksum_algo}}
+        await s3_client.upload_fileobj(fpr, bucket_name, 'test_file', Config=config, **upload_fileobj_kwargs)
+
+    mock_complete_multipart_upload.assert_called_once()
+    args, kwargs = mock_complete_multipart_upload.call_args
+    parts = kwargs['MultipartUpload']['Parts']
+    if checksum_algo:
+        expected_checksum_key = 'Checksum' + checksum_algo
+        for part in parts:
+            assert expected_checksum_key in part
+    else:
+        for part in parts:
+            for key in part:
+                assert not key.startswith('Checksum')
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -192,6 +192,9 @@ async def test_s3_upload_fileobj_async_multipart_completes_with_checksum_on_part
     """This test verifies that when performing a multipart upload with a checksum algorithm:
     1. Each uploaded part includes the specified checksum type (e.g. CRC32 or SHA1)
     2. The complete_multipart_upload call receives all part checksums correctly
+
+    Note that moto does not use checksums properly, hence unittest.mock was used to
+    test the call args of `complete_multipart_upload`
     """
     await s3_client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': region})
 


### PR DESCRIPTION
The method `upload_fileobj` does not correctly upload multipart uploads if checksums are provided. If checksums are provided, this results in a botocore error:

```text
botocore.errorfactory.InvalidRequest: An error occurred (InvalidRequest) when calling the CompleteMultipartUpload operation: The upload was created using a crc32 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request.
```

This PR fixes this small bug by providing the checksums to the individual parts so that the multipart upload can complete.

**Changes**

* Adds the appropriate checksum to multipart uploads in `upload_fileobj` only if `ChecksumAlgorithm` is provided in `ExtraArgs` when `upload_fileobj` is called.
* Adds a unit test to verify `complete_multipart_upload` is called with the right checksums

**Steps to Reproduce Error**

System Info
* aioboto3 14.1.1
* MacOS 14.7.4

The following unittest will reproduce the error. An actual s3 bucket on AWS must be used. Mocked s3 client ignores checksums and so using `moto` will always result in a passing test regardless of checksums.

```python
import aioboto3

@pytest.mark.parametrize('algo', [None, 'CRC32', 'SHA1', 'SHA256'])
@pytest.mark.asyncio
async def test_without_checksum(algo):
    bucket_name = 'actual-s3-bucket'
    data = b'Hello World\n'

    # prepare file
    tmpfile = tempfile.NamedTemporaryFile(delete=False)
    tmpfile.close()
    async with aiofiles.open(tmpfile.name, mode='wb') as fpw:
        await fpw.write(data)
    
    # do multipart upload
    session = aioboto3.Session()
    async with session.client("s3") as s3_client:
        async with aiofiles.open(tmpfile.name, mode='rb') as fpr:
            config = S3TransferConfig(multipart_threshold=4)

            kwargs = {}
            if algo is not None:
                kwargs = dict(ExtraArgs={'ChecksumAlgorithm': algo})
            await s3_client.upload_fileobj(fpr, bucket_name, 'test_file', Config=config, **kwargs)
```

This results in the following error from botocore:

```text
botocore.errorfactory.InvalidRequest: An error occurred (InvalidRequest) when calling the CompleteMultipartUpload operation: The upload was created using a crc32 checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request.
```