### PR TITLE
Fix pending tasks cleanup on cancellation

### DIFF
--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -526,12 +526,9 @@ async def upload_fileobj(
 
     # Close either the Queue.join() coro, or the event.wait() coro
     for coro in pending:
-        if not coro.done():
-            coro.cancel()
-            try:
-                await coro
-            except:
-                pass
+        coro.cancel()
+
+    await asyncio.gather(*pending, return_exceptions=True)
 
     # Cancel any remaining futures, though if successful they'll be done
     cancelled = []


### PR DESCRIPTION
This PR improves the cancellation and cleanup of pending tasks when the parent coroutine is cancelled. Previously, the tasks were being cancelled and awaited **one by one**, which could result in tasks remaining unprocessed if the parent coroutine was cancelled during the loop.

```
[2025-04-28 07:35:55,636: ERROR/MainProcess] Task was destroyed but it is pending!
task: <Task pending name='Task-579' coro=<upload_fileobj.<locals>.uploader() running at /home/scu/.venv/lib/python3.11/site-packages/aioboto3/s3/inject.py:405> wait_for=<Future pending cb=[Task.task_wakeup()]>>
```

With this change, all pending tasks are cancelled first, and then awaited using `asyncio.gather`. This ensures that even if the parent coroutine is cancelled, all tasks are cleaned up properly.

### Example Scenario:
Let's say we have a task that needs to be cancelled due to a timeout (https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for), and multiple other tasks running in the background. In the previous implementation, cancelling these tasks one by one might leave some tasks pending or uncleaned if the parent coroutine is cancelled before all of them are awaited.