### PR TITLE
🧹 Clean up pending tasks on cancellation

### DIFF
--- a/aioboto3/s3/inject.py
+++ b/aioboto3/s3/inject.py
@@ -490,7 +490,13 @@ async def upload_fileobj(
     futures = [asyncio.ensure_future(uploader()) for _ in range(0, Config.max_request_concurrency)]
 
     # Wait for file reader to finish
-    await file_reader_future
+    try:
+        await file_reader_future
+    except asyncio.CancelledError as err:
+        # if the file reader is cancelled, we need to cancel the uploaders too
+        exception_event.set()
+        exception = err
+
     # So by this point all of the file is read and in a queue
 
     # wait for either io queue is finished, or an exception has been raised

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -162,6 +162,8 @@ async def test_s3_upload_fileobj_cancel(event_loop, s3_client, bucket_name, regi
     with pytest.raises(asyncio.CancelledError):
         await upload_task
 
+    assert all([task.cancelled() for task in asyncio.all_tasks() if task is not asyncio.current_task()])
+
 
 @pytest.mark.asyncio
 async def test_s3_upload_empty_fileobj(event_loop, s3_client, bucket_name, region):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import datetime
 import tempfile
@@ -124,6 +125,42 @@ async def test_s3_upload_fileobj(event_loop, s3_client, bucket_name, region):
 
     resp = await s3_client.get_object(Bucket=bucket_name, Key='test_file')
     assert (await resp['Body'].read()) == data
+
+
+@pytest.mark.asyncio
+async def test_s3_upload_fileobj_cancel(event_loop, s3_client, bucket_name, region):
+    data = b"x" * 10_000_000
+    await s3_client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={'LocationConstraint': region}
+    )
+
+    fh = BytesIO(data)
+
+    class SlowFakeFile:
+        def __init__(self, fileobj):
+            self.fileobj = fileobj
+
+        async def read(self, size):
+            await asyncio.sleep(0.1)
+            return self.fileobj.read(size)
+
+    slow_file = SlowFakeFile(fh)
+
+    upload_task = asyncio.create_task(
+        s3_client.upload_fileobj(
+            slow_file,
+            bucket_name,
+            'test_slow_file'
+        )
+    )
+
+    await asyncio.sleep(0.3)
+
+    upload_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await upload_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR enhances the robustness of the S3 upload process by ensuring that all pending asynchronous tasks are properly cancelled if an exception occurs during the upload operation. Specifically:

**Graceful Cancellation:** If an exception is raised during the reading phase of an upload, the corresponding uploader tasks are now explicitly cancelled to prevent them from continuing in the background.

**Test Coverage:** Added unit tests to verify that uploader tasks are correctly cancelled when a reader task fails, ensuring the reliability of this behavior.

These changes aim to prevent potential resource leaks and ensure that the upload process does not leave behind orphaned tasks in the event of an error.

### Observed exception in tests before fixing it

```
<coroutine object upload_fileobj.<locals>.uploader at 0x7f296e0228a0>
  
  Traceback (most recent call last):
    File "/home/runner/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/queues.py", line 158, in get
      await getter
  GeneratorExit
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/runner/work/aioboto3/aioboto3/aioboto3/s3/inject.py", line 405, in uploader
      part_args = await io_queue.get()
                  ^^^^^^^^^^^^^^^^^^^^
    File "/home/runner/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/queues.py", line 160, in get
      getter.cancel()  # Just in case getter is not done yet.
      ^^^^^^^^^^^^^^^
    File "/home/runner/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 762, in call_soon
      self._check_closed()
    File "/home/runner/.local/share/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/asyncio/base_events.py", line 520, in _check_closed
Error:       raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
```

### How to test it
```
pytest -vv --pdb tests/test_s3.py::test_s3_upload_fileobj_cancel
```
