### PR TITLE
chore: unpin a redundant `Python 4` upper bound version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
     {name = "Terri Cain", email = "terri@dolphincorp.co.uk"},
 ]
 license = {text = "Apache-2.0"}
-requires-python = "<4.0,>=3.9"
+requires-python = ">=3.9"
 dependencies = [
     "aiobotocore[boto3]==2.23.0",
     "aiofiles>=23.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.9, <4.0"
+requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11'",
     "python_full_version == '3.10.*'",
@@ -1001,7 +1001,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
[when should I pin deps: never and always!](https://www.youtube.com/watch?v=WSVFw-3ssXM)

This unnecessary upper bound comes from Poetry. Fortunately, `uv` is smarter, and new projects are initialized only with the lower bound by default.